### PR TITLE
Add client-side QA crawler tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Once deployed, visit `https://<your-worker>/image-qa?url=https://example.com`
 to crawl a site and display its images. Use the size slider at the top of the
 results page to highlight files above a given threshold.
 
+## Client-side QA Crawler
+
+Navigate to `/qa-crawler` to gather basic page metadata directly in the
+browser. The worker serves a self-contained page that loads each internal link
+in a hidden iframe, extracts the title, meta description, H1–H3 headings, and
+word count, and displays the results in a table. Because the crawling runs in
+the client, DOM access is limited to same-origin pages and sites with strict
+CORS or `X-Frame-Options` headers may return empty data or 403 errors.
+
+### Usage
+
+Visit `https://<your-worker>/qa-crawler`, enter a base URL, and click **Start**.
+
 ### Local Development
 
 Install [Wrangler](https://github.com/cloudflare/wrangler) and start a


### PR DESCRIPTION
## Summary
- serve a new `/qa-crawler` page with a browser-only crawler that extracts metadata and follows internal links
- link the client-side crawler from the hub page and document it in the README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check worker.js`


------
https://chatgpt.com/codex/tasks/task_e_689161ee1e008325aec0235be77eb5db