### PR TITLE
Add Chrome extension for page crawling

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,49 @@
+// Content script injected into every page.
+// Waits for the page to load, collects metadata, and sends it back
+// to the extension's background service worker.
+
+// Helper function to gather all required data from the DOM.
+function collectPageData() {
+  // Page title
+  const title = document.title;
+
+  // All <meta> tags with name, property, and content attributes
+  const metas = Array.from(document.querySelectorAll('meta')).map((m) => ({
+    name: m.getAttribute('name') || '',
+    property: m.getAttribute('property') || '',
+    content: m.getAttribute('content') || '',
+  }));
+
+  // Text content of headings
+  const headings = {
+    h1: Array.from(document.querySelectorAll('h1')).map((e) => e.textContent.trim()),
+    h2: Array.from(document.querySelectorAll('h2')).map((e) => e.textContent.trim()),
+    h3: Array.from(document.querySelectorAll('h3')).map((e) => e.textContent.trim()),
+  };
+
+  // Visible body text word count
+  const bodyText = document.body.innerText || '';
+  const wordCount = bodyText.trim().split(/\s+/).filter(Boolean).length;
+
+  // Full HTML and its length
+  const html = document.documentElement.innerHTML;
+  const htmlLength = html.length;
+
+  return { title, metas, headings, wordCount, htmlLength, html };
+}
+
+// Sends the collected data to the background script
+function sendData() {
+  const data = collectPageData();
+  chrome.runtime.sendMessage({ type: 'pageData', data });
+}
+
+// Automatically crawl once the page has fully loaded
+window.addEventListener('load', sendData);
+
+// Also respond to explicit crawl requests from the background/popup
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg && msg.type === 'crawl') {
+    sendData();
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "QA Crawler",
+  "version": "1.0",
+  "description": "Crawl page metadata for QA purposes.",
+  "permissions": ["activeTab", "tabs", "scripting", "storage"],
+  "host_permissions": ["<all_urls>"],
+  "action": {
+    "default_title": "QA Crawler",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "service_worker.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle",
+      "all_frames": false
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>QA Crawler</title>
+  <style>
+    body { min-width: 300px; font-family: Arial, sans-serif; }
+    button { margin-bottom: 10px; }
+    pre { white-space: pre-wrap; word-break: break-word; }
+  </style>
+</head>
+<body>
+  <button id="crawl">Crawl This Page</button>
+  <pre id="output"></pre>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,35 @@
+// Popup script: sends crawl requests and displays results.
+
+const output = document.getElementById('output');
+const crawlBtn = document.getElementById('crawl');
+
+// Display the JSON data in the popup
+function display(data) {
+  output.textContent = JSON.stringify(data, null, 2);
+}
+
+// Optionally send the data to a Cloudflare Worker endpoint
+async function reportToWorker(data) {
+  try {
+    await fetch('https://your-worker.workers.dev/api/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  } catch (err) {
+    console.error('Reporting failed', err);
+  }
+}
+
+// Listen for messages from the background script containing page data
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg && msg.type === 'pageData') {
+    display(msg.data);
+    reportToWorker(msg.data); // Optional reporting
+  }
+});
+
+// Trigger crawling of the active tab
+crawlBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'crawlPage' });
+});

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -1,0 +1,36 @@
+// Background service worker for the extension.
+// Handles communication between popup and content scripts
+// and optionally forwards data to a Cloudflare Worker endpoint.
+
+// Handle messages from popup and content scripts
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  // Popup requests a crawl of the current active tab
+  if (msg && msg.type === 'crawlPage') {
+    (async () => {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (!tab || !tab.id) return;
+
+      try {
+        // Ask existing content script to crawl
+        await chrome.tabs.sendMessage(tab.id, { type: 'crawl' });
+      } catch (e) {
+        // If the content script isn't injected yet, inject it and try again
+        await chrome.scripting.executeScript({ target: { tabId: tab.id }, files: ['content.js'] });
+        await chrome.tabs.sendMessage(tab.id, { type: 'crawl' });
+      }
+    })();
+  }
+
+  // Content script has sent back the page data
+  if (msg && msg.type === 'pageData') {
+    // Forward to popup
+    chrome.runtime.sendMessage(msg);
+
+    // Optionally report to a Cloudflare Worker endpoint
+    fetch('https://your-worker.workers.dev/api/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(msg.data),
+    }).catch((err) => console.error('Reporting failed', err));
+  }
+});


### PR DESCRIPTION
## Summary
- add Manifest V3 Chrome extension scaffolded in `/extension`
- collect page metadata and headings via content script
- popup triggers crawling and optionally reports to Cloudflare Worker

## Testing
- `node --check extension/content.js`
- `node --check extension/popup.js`
- `node --check extension/service_worker.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689164e26e8c83258be2959e3cb44910