### PR TITLE
Connect extension to worker and enhance image QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ tools.
 
 Navigate to `/image-qa` to use the image quality assurance utility. After
 entering a website URL, the worker crawls all internal links, gathers the
-images on each page, and sorts them by file size. A slider allows QA
+images on each page, and sorts them by file size. A numeric input allows QA
 engineers to highlight images above a chosen threshold (1 KB–100 MB) for
-review. Each page is labeled with its `<h1>` text and every image displays
+review. Each page is labeled with its `<title>` text and every image displays
 its file size and `alt` text.
 
 ### Usage
 
 Once deployed, visit `https://<your-worker>/image-qa?url=https://example.com`
-to crawl a site and display its images. Use the size slider at the top of the
+to crawl a site and display its images. Use the size input at the top of the
 results page to highlight files above a given threshold.
 
 ## Client-side QA Crawler

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "QA Crawler",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Crawl page metadata for QA purposes.",
   "permissions": ["activeTab", "tabs", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -10,6 +10,9 @@
   </style>
 </head>
 <body>
+  <p>Last updated: <span id="buildDate"></span></p>
+  <input id="siteUrl" type="url" placeholder="https://example.com">
+  <button id="runImageQa">Run Image QA</button>
   <button id="crawl">Crawl This Page</button>
   <pre id="output"></pre>
   <script src="popup.js"></script>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,7 +1,13 @@
 // Popup script: sends crawl requests and displays results.
 
+const BUILD_DATE = '__BUILD_DATE__';
 const output = document.getElementById('output');
 const crawlBtn = document.getElementById('crawl');
+const runImageQaBtn = document.getElementById('runImageQa');
+const siteInput = document.getElementById('siteUrl');
+
+const buildDate = new Date(BUILD_DATE);
+document.getElementById('buildDate').textContent = isNaN(buildDate) ? 'unknown' : buildDate.toLocaleDateString();
 
 // Display the JSON data in the popup
 function display(data) {
@@ -11,7 +17,7 @@ function display(data) {
 // Optionally send the data to a Cloudflare Worker endpoint
 async function reportToWorker(data) {
   try {
-    await fetch('https://your-worker.workers.dev/api/report', {
+    await fetch('https://qa-tools-worker.jordan-evans.workers.dev/api/report', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -32,4 +38,11 @@ chrome.runtime.onMessage.addListener((msg) => {
 // Trigger crawling of the active tab
 crawlBtn.addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'crawlPage' });
+});
+
+runImageQaBtn.addEventListener('click', () => {
+  const url = siteInput.value.trim();
+  if (!url) return;
+  const target = `https://qa-tools-worker.jordan-evans.workers.dev/image-qa?url=${encodeURIComponent(url)}`;
+  chrome.tabs.create({ url: target });
 });

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -27,7 +27,7 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     chrome.runtime.sendMessage(msg);
 
     // Optionally report to a Cloudflare Worker endpoint
-    fetch('https://your-worker.workers.dev/api/report', {
+    fetch('https://qa-tools-worker.jordan-evans.workers.dev/api/report', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(msg.data),


### PR DESCRIPTION
## Summary
- expose image QA endpoint to extension with CORS and absolute worker URLs
- use page `<title>` text and numeric size input when crawling images
- extension shows build date and launches image QA via worker

## Testing
- `node --version`
- `node --check worker.js`
- `node --check extension/popup.js`
- `node --check extension/service_worker.js`
- `node --check extension/content.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916c259558832584d0194a5dc4e10f