### PR TITLE
feat: crawl sites locally for image QA

### DIFF
--- a/extension/image_results.html
+++ b/extension/image_results.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Image QA Result</title>
+  <style>
+    .image { margin:10px; display:inline-block; }
+    .image.oversize { outline:3px solid red; }
+  </style>
+</head>
+<body>
+  <h1>Image QA Result</h1>
+  <label>Highlight images above (KB): <input type="number" id="sizeInput" min="1" max="102400" value="1"></label>
+  <div id="results"></div>
+  <script src="image_results.js"></script>
+</body>
+</html>

--- a/extension/image_results.js
+++ b/extension/image_results.js
@@ -1,0 +1,53 @@
+function formatSize(n) {
+  if (n > 1024 * 1024) return (n / 1024 / 1024).toFixed(2) + ' MB';
+  if (n > 1024) return (n / 1024).toFixed(2) + ' KB';
+  return n + ' B';
+}
+
+function escapeHtml(str) {
+  return str.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  })[c]);
+}
+
+const container = document.getElementById('results');
+
+chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
+  if (!imageQaData) {
+    container.textContent = 'No data.';
+    return;
+  }
+
+  for (const [pageUrl, data] of Object.entries(imageQaData)) {
+    const h2 = document.createElement('h2');
+    const link = document.createElement('a');
+    link.href = pageUrl;
+    link.textContent = data.title;
+    h2.appendChild(link);
+    container.appendChild(h2);
+
+    for (const img of data.images) {
+      const div = document.createElement('div');
+      div.className = 'image';
+      div.dataset.size = img.size;
+      div.innerHTML = `<img src="${img.url}" alt="${escapeHtml(img.alt)}" loading="lazy"><br><span>${formatSize(img.size)}</span><br><em>Alt: ${escapeHtml(img.alt)}</em>`;
+      container.appendChild(div);
+    }
+  }
+
+  const input = document.getElementById('sizeInput');
+  function update() {
+    const threshold = Number(input.value) * 1024;
+    document.querySelectorAll('.image').forEach((el) => {
+      el.classList.toggle('oversize', Number(el.dataset.size) > threshold);
+    });
+  }
+  input.addEventListener('input', update);
+  update();
+
+  chrome.storage.local.remove('imageQaData');
+});

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -43,6 +43,5 @@ crawlBtn.addEventListener('click', () => {
 runImageQaBtn.addEventListener('click', () => {
   const url = siteInput.value.trim();
   if (!url) return;
-  const target = `https://qa-tools-worker.jordan-evans.workers.dev/image-qa?url=${encodeURIComponent(url)}`;
-  chrome.tabs.create({ url: target });
+  chrome.runtime.sendMessage({ type: 'startImageQa', url });
 });

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -2,6 +2,8 @@
 // Handles communication between popup and content scripts
 // and optionally forwards data to a Cloudflare Worker endpoint.
 
+let crawlTabId = null;
+
 // Handle messages from popup and content scripts
 chrome.runtime.onMessage.addListener((msg, sender) => {
   // Popup requests a crawl of the current active tab
@@ -19,6 +21,32 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
         await chrome.tabs.sendMessage(tab.id, { type: 'crawl' });
       }
     })();
+  }
+
+  // Start an image QA crawl using the local browser
+  if (msg && msg.type === 'startImageQa') {
+    (async () => {
+      const tab = await chrome.tabs.create({ url: msg.url });
+      crawlTabId = tab.id;
+      const listener = (tabId, info) => {
+        if (tabId === tab.id && info.status === 'complete') {
+          chrome.tabs.onUpdated.removeListener(listener);
+          chrome.tabs.sendMessage(tab.id, { type: 'startImageQa', url: msg.url });
+        }
+      };
+      chrome.tabs.onUpdated.addListener(listener);
+    })();
+  }
+
+  // Content script has finished crawling and sent back results
+  if (msg && msg.type === 'imageQaResult') {
+    chrome.storage.local.set({ imageQaData: msg.pages }, () => {
+      chrome.tabs.create({ url: chrome.runtime.getURL('image_results.html') });
+    });
+    if (crawlTabId) {
+      chrome.tabs.remove(crawlTabId);
+      crawlTabId = null;
+    }
   }
 
   // Content script has sent back the page data


### PR DESCRIPTION
## Summary
- allow content script to fetch and crawl all internal pages for images
- orchestrate local crawl from service worker and show results in new tab
- render image details in extension page and highlight oversize files

## Testing
- `node --check extension/content.js && node --check extension/popup.js && node --check extension/service_worker.js && node --check extension/image_results.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916e011fa08325b73e6225051dc170