### PR TITLE
feat: add crawl progress and image browsing aids

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -97,6 +97,11 @@ async function crawlSite(startUrl) {
         }
       } catch (e) {}
     }
+    chrome.runtime.sendMessage({
+      type: 'crawlProgress',
+      crawled: visited.size,
+      discovered: visited.size + queue.length,
+    });
   }
   return pages;
 }

--- a/extension/image_results.html
+++ b/extension/image_results.html
@@ -5,7 +5,19 @@
   <title>Image QA Result</title>
   <style>
     .image { margin:10px; display:inline-block; }
+    .image img { width:200px; height:200px; object-fit:cover; display:block; }
     .image.oversize { outline:3px solid red; }
+    #pageIndicator {
+      position:fixed;
+      top:10px;
+      right:10px;
+      background:rgba(0,0,0,0.7);
+      color:#fff;
+      padding:5px 10px;
+      border-radius:4px;
+      z-index:1000;
+      font-family:Arial, sans-serif;
+    }
   </style>
 </head>
 <body>

--- a/extension/image_results.js
+++ b/extension/image_results.js
@@ -15,6 +15,9 @@ function escapeHtml(str) {
 }
 
 const container = document.getElementById('results');
+const indicator = document.createElement('div');
+indicator.id = 'pageIndicator';
+document.body.appendChild(indicator);
 
 chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
   if (!imageQaData) {
@@ -22,7 +25,8 @@ chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
     return;
   }
 
-  for (const [pageUrl, data] of Object.entries(imageQaData)) {
+  const pages = Object.entries(imageQaData);
+  for (const [pageUrl, data] of pages) {
     const h2 = document.createElement('h2');
     const link = document.createElement('a');
     link.href = pageUrl;
@@ -38,6 +42,23 @@ chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
       container.appendChild(div);
     }
   }
+
+  const headers = Array.from(container.querySelectorAll('h2'));
+  function updateIndicator() {
+    let current = 0;
+    for (let i = 0; i < headers.length; i++) {
+      if (headers[i].getBoundingClientRect().top - 60 <= 0) {
+        current = i;
+      } else {
+        break;
+      }
+    }
+    const prev = headers[current - 1] ? headers[current - 1].textContent : 'None';
+    const next = headers[current + 1] ? headers[current + 1].textContent : 'None';
+    indicator.innerHTML = `<strong>Page ${current + 1} / ${headers.length}</strong><br><em>Prev:</em> ${prev}<br><em>Next:</em> ${next}`;
+  }
+  window.addEventListener('scroll', updateIndicator);
+  updateIndicator();
 
   const input = document.getElementById('sizeInput');
   function update() {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -14,6 +14,7 @@
   <input id="siteUrl" type="url" placeholder="https://example.com">
   <button id="runImageQa">Run Image QA</button>
   <button id="crawl">Crawl This Page</button>
+  <div id="progress"></div>
   <pre id="output"></pre>
   <script src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -5,6 +5,7 @@ const output = document.getElementById('output');
 const crawlBtn = document.getElementById('crawl');
 const runImageQaBtn = document.getElementById('runImageQa');
 const siteInput = document.getElementById('siteUrl');
+const progress = document.getElementById('progress');
 
 const buildDate = new Date(BUILD_DATE);
 document.getElementById('buildDate').textContent = isNaN(buildDate) ? 'unknown' : buildDate.toLocaleDateString();
@@ -32,6 +33,9 @@ chrome.runtime.onMessage.addListener((msg) => {
   if (msg && msg.type === 'pageData') {
     display(msg.data);
     reportToWorker(msg.data); // Optional reporting
+  }
+  if (msg && msg.type === 'crawlProgress') {
+    progress.textContent = `Crawled ${msg.crawled} / Discovered ${msg.discovered}`;
   }
 });
 

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -61,4 +61,7 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
       body: JSON.stringify(msg.data),
     }).catch((err) => console.error('Reporting failed', err));
   }
+  if (msg && msg.type === 'crawlProgress') {
+    chrome.runtime.sendMessage(msg);
+  }
 });


### PR DESCRIPTION
## Summary
- standardize image dimensions and add floating page tracker for image QA results
- report crawl progress as pages are visited and discovered
- show live crawl progress within the popup UI

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891780f9a3883258f968961072b0086