### PR TITLE
Avoid downloading images in QA tool

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -74,15 +74,9 @@ async function crawlSite(startUrl) {
       const imgUrl = new URL(src, normalized).href;
       const altMatch = tag.match(/alt=["']([^"']*)["']/i);
       const alt = altMatch ? altMatch[1] : '';
-      let size = 0;
-      try {
-        const head = await fetch(imgUrl, { method: 'HEAD' });
-        size = parseInt(head.headers.get('content-length')) || 0;
-      } catch (err) {}
-      images.push({ url: imgUrl, alt, size });
+      // Only record the image URL and alt text; do not fetch the image.
+      images.push({ url: imgUrl, alt });
     }
-
-    images.sort((a, b) => b.size - a.size);
     pages[normalized] = { title, images };
 
     const linkRegex = /<a[^>]*href=["']([^"']+)["'][^>]*>/gi;

--- a/extension/image_results.html
+++ b/extension/image_results.html
@@ -6,7 +6,6 @@
   <style>
     .image { margin:10px; display:inline-block; }
     .image img { width:200px; height:200px; object-fit:cover; display:block; }
-    .image.oversize { outline:3px solid red; }
     #pageIndicator {
       position:fixed;
       top:10px;
@@ -22,7 +21,6 @@
 </head>
 <body>
   <h1>Image QA Result</h1>
-  <label>Highlight images above (KB): <input type="number" id="sizeInput" min="1" max="102400" value="1"></label>
   <div id="results"></div>
   <script src="image_results.js"></script>
 </body>

--- a/extension/image_results.js
+++ b/extension/image_results.js
@@ -1,9 +1,3 @@
-function formatSize(n) {
-  if (n > 1024 * 1024) return (n / 1024 / 1024).toFixed(2) + ' MB';
-  if (n > 1024) return (n / 1024).toFixed(2) + ' KB';
-  return n + ' B';
-}
-
 function escapeHtml(str) {
   return str.replace(/[&<>"']/g, (c) => ({
     '&': '&amp;',
@@ -37,8 +31,8 @@ chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
     for (const img of data.images) {
       const div = document.createElement('div');
       div.className = 'image';
-      div.dataset.size = img.size;
-      div.innerHTML = `<img src="${img.url}" alt="${escapeHtml(img.alt)}" loading="lazy"><br><span>${formatSize(img.size)}</span><br><em>Alt: ${escapeHtml(img.alt)}</em>`;
+      // Display the image using its direct URL without downloading it in advance.
+      div.innerHTML = `<img src="${img.url}" alt="${escapeHtml(img.alt)}" loading="lazy"><br><em>Alt: ${escapeHtml(img.alt)}</em>`;
       container.appendChild(div);
     }
   }
@@ -59,16 +53,6 @@ chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
   }
   window.addEventListener('scroll', updateIndicator);
   updateIndicator();
-
-  const input = document.getElementById('sizeInput');
-  function update() {
-    const threshold = Number(input.value) * 1024;
-    document.querySelectorAll('.image').forEach((el) => {
-      el.classList.toggle('oversize', Number(el.dataset.size) > threshold);
-    });
-  }
-  input.addEventListener('input', update);
-  update();
 
   chrome.storage.local.remove('imageQaData');
 });


### PR DESCRIPTION
## Summary
- Skip HEAD requests for images during crawling and only capture URLs/alt text
- Display images on results page via direct URLs without file size or download attempts
- Clean up HTML results page to remove unused size filter and oversize styling

## Testing
- `npm test` (fails: ENOENT package.json)
- `node --check extension/content.js`
- `node --check extension/image_results.js`


------
https://chatgpt.com/codex/tasks/task_e_689179a6d7f48325ab0cb195b8867846