### PR TITLE
Add header crawler tool and file size filters

### DIFF
--- a/extension/header_results.html
+++ b/extension/header_results.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Header Structure Result</title>
+  <style>
+    .page { margin-bottom: 2rem; }
+    .h1 { color: red; }
+    .h2 { color: green; }
+    .h3 { color: blue; }
+  </style>
+</head>
+<body>
+  <h1>Header Structure Result</h1>
+  <label>Min HTML size (bytes): <input type="number" id="sizeFilter" min="0"></label>
+  <button id="applyFilter">Filter</button>
+  <div id="results"></div>
+  <script src="header_results.js"></script>
+</body>
+</html>

--- a/extension/header_results.js
+++ b/extension/header_results.js
@@ -1,0 +1,43 @@
+const container = document.getElementById('results');
+
+chrome.storage.local.get('headerQaData').then(({ headerQaData }) => {
+  if (!headerQaData) {
+    container.textContent = 'No data.';
+    return;
+  }
+
+  for (const [url, data] of Object.entries(headerQaData)) {
+    const section = document.createElement('section');
+    section.className = 'page';
+    section.dataset.size = data.size;
+
+    const h2 = document.createElement('h2');
+    const link = document.createElement('a');
+    link.href = url;
+    link.textContent = data.title;
+    h2.appendChild(link);
+    section.appendChild(h2);
+
+    ['h1','h2','h3'].forEach(level => {
+      data.headings[level].forEach(text => {
+        const div = document.createElement('div');
+        div.className = level;
+        div.textContent = text;
+        section.appendChild(div);
+      });
+    });
+
+    container.appendChild(section);
+  }
+
+  const applyFilter = () => {
+    const min = parseInt(document.getElementById('sizeFilter').value, 10) || 0;
+    document.querySelectorAll('.page').forEach(sec => {
+      const size = parseInt(sec.dataset.size, 10) || 0;
+      sec.style.display = size >= min ? '' : 'none';
+    });
+  };
+
+  document.getElementById('applyFilter').addEventListener('click', applyFilter);
+  chrome.storage.local.remove('headerQaData');
+});

--- a/extension/image_results.html
+++ b/extension/image_results.html
@@ -6,6 +6,7 @@
   <style>
     .image { margin:10px; display:inline-block; }
     .image img { width:200px; height:200px; object-fit:cover; display:block; }
+    .image.oversize { outline:3px solid red; }
     #pageIndicator {
       position:fixed;
       top:10px;
@@ -21,6 +22,7 @@
 </head>
 <body>
   <h1>Image QA Result</h1>
+  <label>Highlight images above (KB): <input type="number" id="sizeInput" min="1" max="102400" value="1"></label>
   <div id="results"></div>
   <script src="image_results.js"></script>
 </body>

--- a/extension/image_results.js
+++ b/extension/image_results.js
@@ -8,6 +8,12 @@ function escapeHtml(str) {
   })[c]);
 }
 
+function formatSize(n) {
+  if (n > 1024 * 1024) return (n / 1024 / 1024).toFixed(2) + ' MB';
+  if (n > 1024) return (n / 1024).toFixed(2) + ' KB';
+  return n + ' B';
+}
+
 const container = document.getElementById('results');
 const indicator = document.createElement('div');
 indicator.id = 'pageIndicator';
@@ -31,8 +37,8 @@ chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
     for (const img of data.images) {
       const div = document.createElement('div');
       div.className = 'image';
-      // Display the image using its direct URL without downloading it in advance.
-      div.innerHTML = `<img src="${img.url}" alt="${escapeHtml(img.alt)}" loading="lazy"><br><em>Alt: ${escapeHtml(img.alt)}</em>`;
+      div.dataset.size = img.size;
+      div.innerHTML = `<img src="${img.url}" alt="${escapeHtml(img.alt)}" loading="lazy"><br><span>${formatSize(img.size)}</span><br><em>Alt: ${escapeHtml(img.alt)}</em>`;
       container.appendChild(div);
     }
   }
@@ -55,4 +61,14 @@ chrome.storage.local.get('imageQaData').then(({ imageQaData }) => {
   updateIndicator();
 
   chrome.storage.local.remove('imageQaData');
+
+  const sizeInput = document.getElementById('sizeInput');
+  function update() {
+    const threshold = Number(sizeInput.value) * 1024;
+    document.querySelectorAll('.image').forEach(el => {
+      el.classList.toggle('oversize', Number(el.dataset.size) > threshold);
+    });
+  }
+  sizeInput.addEventListener('input', update);
+  update();
 });

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -13,6 +13,7 @@
   <p>Last updated: <span id="buildDate"></span></p>
   <input id="siteUrl" type="url" placeholder="https://example.com">
   <button id="runImageQa">Run Image QA</button>
+  <button id="runHeaderQa">Run Header QA</button>
   <button id="crawl">Crawl This Page</button>
   <div id="progress"></div>
   <pre id="output"></pre>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -4,6 +4,7 @@ const BUILD_DATE = '__BUILD_DATE__';
 const output = document.getElementById('output');
 const crawlBtn = document.getElementById('crawl');
 const runImageQaBtn = document.getElementById('runImageQa');
+const runHeaderQaBtn = document.getElementById('runHeaderQa');
 const siteInput = document.getElementById('siteUrl');
 const progress = document.getElementById('progress');
 
@@ -48,4 +49,10 @@ runImageQaBtn.addEventListener('click', () => {
   const url = siteInput.value.trim();
   if (!url) return;
   chrome.runtime.sendMessage({ type: 'startImageQa', url });
+});
+
+runHeaderQaBtn.addEventListener('click', () => {
+  const url = siteInput.value.trim();
+  if (!url) return;
+  chrome.runtime.sendMessage({ type: 'startHeaderQa', url });
 });


### PR DESCRIPTION
## Summary
- Replace meta description crawl with page H1 and add HTML size filter to QA crawler
- Include H1 in collected page data and fetch image file sizes for filtering
- Add new header-structure crawling tool with color-coded headings and size filtering

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68917bcf107c83259d56b0a6246711ba