### PR TITLE
Normalize URLs during crawl

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -28,15 +28,25 @@ function sendData() {
 window.addEventListener('load', sendData);
 
 // Crawl an entire site by fetching each internal page and gathering image data.
+function stripHash(u) {
+  try {
+    const url = new URL(u);
+    url.hash = '';
+    return url.href;
+  } catch {
+    return u;
+  }
+}
+
 async function crawlSite(startUrl) {
   const origin = new URL(startUrl).origin;
-  const queue = [startUrl];
+  const queue = [stripHash(startUrl)];
   const visited = new Set();
   const pages = {};
 
   while (queue.length) {
     const current = queue.shift();
-    const normalized = new URL(current, origin).href;
+    const normalized = stripHash(new URL(current, origin).href);
     if (visited.has(normalized)) continue;
     visited.add(normalized);
 
@@ -57,7 +67,7 @@ async function crawlSite(startUrl) {
     while ((imgMatch = imgRegex.exec(html)) !== null) {
       const tag = imgMatch[0];
       const src = imgMatch[1];
-      const imgUrl = new URL(src, normalized).href;
+      const imgUrl = stripHash(new URL(src, normalized).href);
       const altMatch = tag.match(/alt=["']([^"']*)["']/i);
       const alt = altMatch ? altMatch[1] : '';
       let size = 0;
@@ -75,7 +85,7 @@ async function crawlSite(startUrl) {
       const href = linkMatch[1];
       if (href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('javascript:')) continue;
       try {
-        const link = new URL(href, normalized).href;
+        const link = stripHash(new URL(href, normalized).href);
         if (link.startsWith(origin) && !visited.has(link)) {
           queue.push(link);
         }
@@ -96,13 +106,13 @@ function stripTags(str) {
 
 async function crawlSiteHeaders(startUrl) {
   const origin = new URL(startUrl).origin;
-  const queue = [startUrl];
+  const queue = [stripHash(startUrl)];
   const visited = new Set();
   const pages = {};
 
   while (queue.length) {
     const current = queue.shift();
-    const normalized = new URL(current, origin).href;
+    const normalized = stripHash(new URL(current, origin).href);
     if (visited.has(normalized)) continue;
     visited.add(normalized);
 
@@ -130,12 +140,12 @@ async function crawlSiteHeaders(startUrl) {
       const href = linkMatch[1];
       if (href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('javascript:')) continue;
       try {
-        const link = new URL(href, normalized).href;
+        const link = stripHash(new URL(href, normalized).href);
         if (link.startsWith(origin) && !visited.has(link)) {
           queue.push(link);
         }
       } catch (e) {}
-    }
+  }
   }
   return pages;
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <p>Last updated: <span id="buildDate"></span></p>
-  <input id="siteUrl" type="url" placeholder="https://example.com">
   <button id="runImageQa">Run Image QA</button>
   <button id="runHeaderQa">Run Header QA</button>
   <button id="crawl">Crawl This Page</button>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -5,7 +5,6 @@ const output = document.getElementById('output');
 const crawlBtn = document.getElementById('crawl');
 const runImageQaBtn = document.getElementById('runImageQa');
 const runHeaderQaBtn = document.getElementById('runHeaderQa');
-const siteInput = document.getElementById('siteUrl');
 const progress = document.getElementById('progress');
 
 const buildDate = new Date(BUILD_DATE);
@@ -46,13 +45,9 @@ crawlBtn.addEventListener('click', () => {
 });
 
 runImageQaBtn.addEventListener('click', () => {
-  const url = siteInput.value.trim();
-  if (!url) return;
-  chrome.runtime.sendMessage({ type: 'startImageQa', url });
+  chrome.runtime.sendMessage({ type: 'startImageQa' });
 });
 
 runHeaderQaBtn.addEventListener('click', () => {
-  const url = siteInput.value.trim();
-  if (!url) return;
-  chrome.runtime.sendMessage({ type: 'startHeaderQa', url });
+  chrome.runtime.sendMessage({ type: 'startHeaderQa' });
 });


### PR DESCRIPTION
## Summary
- avoid crawling anchor URLs as separate pages by normalizing links
- run QA crawls on the current tab when popup buttons are pressed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689180832bec83258c19b7691801296d