### PR TITLE
Ensure button QA includes page CSS for accurate rendering

### DIFF
--- a/extension/button_results.js
+++ b/extension/button_results.js
@@ -14,12 +14,22 @@ chrome.storage.local.get('buttonQaData').then(({ buttonQaData }) => {
     h2.appendChild(link);
     container.appendChild(h2);
 
-    data.buttons.forEach(btn => {
+    const wrapper = document.createElement('div');
+    const shadow = wrapper.attachShadow({ mode: 'open' });
+
+    const style = document.createElement('style');
+    const pageStyles = (data.styles || []).join('\n');
+    style.textContent = `.button { margin:10px; display:inline-block; }\n${pageStyles}`;
+    shadow.appendChild(style);
+
+    (data.buttons || []).forEach(btn => {
       const div = document.createElement('div');
       div.className = 'button';
       div.innerHTML = btn.html;
-      container.appendChild(div);
+      shadow.appendChild(div);
     });
+
+    container.appendChild(wrapper);
   }
 
   chrome.storage.local.remove('buttonQaData');

--- a/extension/content.js
+++ b/extension/content.js
@@ -176,7 +176,22 @@ async function crawlSiteButtons(startUrl) {
     doc.querySelectorAll('a, button, [role="button"]').forEach(el => {
       buttons.push({ html: el.outerHTML, href: el.getAttribute('href') || '' });
     });
-    pages[normalized] = { title, buttons };
+
+    const styles = [];
+    doc.querySelectorAll('style').forEach(styleEl => {
+      styles.push(styleEl.textContent);
+    });
+    for (const linkEl of doc.querySelectorAll('link[rel="stylesheet"]')) {
+      const href = linkEl.getAttribute('href');
+      if (!href) continue;
+      try {
+        const cssUrl = new URL(href, normalized).href;
+        const res = await fetch(cssUrl, { credentials: 'include' });
+        styles.push(await res.text());
+      } catch (e) {}
+    }
+
+    pages[normalized] = { title, buttons, styles };
 
     const linkRegex = /<a[^>]*href=["']([^"']+)["'][^>]*>/gi;
     let linkMatch;


### PR DESCRIPTION
## Summary
- capture inline and external stylesheets when crawling buttons
- render each page's buttons within a shadow DOM and inject collected CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68918725b8dc8325916b755fa4e5f1bb