### PR TITLE
fix: update GitHub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ add it.
 
 ### Install the extension
 
-1. Download this repository from [GitHub](https://github.com/jordan-evans/Tools)
-   (use **Code → Download ZIP**).
+1. Download this repository from [GitHub](https://github.com/JordanDavidEvans/Tools)
+   (use **Code → Download ZIP** or [download the ZIP directly](https://github.com/JordanDavidEvans/Tools/archive/refs/heads/main.zip)).
 2. Unzip the archive and locate the `extension` folder.
 3. In Chrome, open `chrome://extensions`, enable **Developer mode**, click
    **Load unpacked**, and select the `extension` folder.

--- a/worker.js
+++ b/worker.js
@@ -158,7 +158,7 @@ function start(url){
     chrome.runtime.sendMessage({type:'startImageQa', url});
     document.getElementById('status').textContent = 'Extension detected. Results will open in a new tab.';
   } else {
-    document.getElementById('status').innerHTML = 'Chrome extension not detected. Download it from <a href="https://github.com/jordan-evans/Tools">GitHub</a>, unzip it, then load the "extension" folder via chrome://extensions using "Load unpacked".';
+    document.getElementById('status').innerHTML = 'Chrome extension not detected. Download it from <a href="https://github.com/JordanDavidEvans/Tools/archive/refs/heads/main.zip">GitHub</a>, unzip it, then load the "extension" folder via chrome://extensions using "Load unpacked".';
   }
 }
 document.getElementById('qaForm').addEventListener('submit', e => {
@@ -190,7 +190,7 @@ document.getElementById('startBtn').addEventListener('click', () => {
     chrome.runtime.sendMessage({type:'startHeaderQa', url});
     document.getElementById('status').textContent = 'Extension detected. Results will open in a new tab.';
   } else {
-    document.getElementById('status').innerHTML = 'Chrome extension not detected. Download it from <a href="https://github.com/jordan-evans/Tools">GitHub</a>, unzip it, then load the "extension" folder via chrome://extensions using "Load unpacked".';
+    document.getElementById('status').innerHTML = 'Chrome extension not detected. Download it from <a href="https://github.com/JordanDavidEvans/Tools/archive/refs/heads/main.zip">GitHub</a>, unzip it, then load the "extension" folder via chrome://extensions using "Load unpacked".';
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- update README and worker links to point to JordanDavidEvans/Tools and provide direct ZIP download

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66d5bf2988325908fee94672f2487